### PR TITLE
Flash - Make devanagari the top choice for the Sanskrit Script in Settings

### DIFF
--- a/031-flash/elm.js
+++ b/031-flash/elm.js
@@ -7839,43 +7839,6 @@ var $author$project$Main$scriptFieldSet = function (model) {
 										$elm$html$Html$input,
 										_List_fromArray(
 											[
-												$elm$html$Html$Attributes$id('latin'),
-												$elm$html$Html$Attributes$name('script'),
-												$elm$html$Html$Attributes$type_('radio'),
-												$elm$html$Html$Attributes$value('Latin'),
-												$elm$html$Html$Events$onInput($author$project$Types$SetScript),
-												$elm$html$Html$Attributes$checked(!model.bi.bf)
-											]),
-										_List_Nil)
-									])),
-								A2(
-								$elm$html$Html$td,
-								_List_Nil,
-								_List_fromArray(
-									[
-										A2(
-										$elm$html$Html$label,
-										_List_fromArray(
-											[
-												$elm$html$Html$Attributes$for('latin')
-											]),
-										$author$project$Main$radioScriptLabelHtml(0))
-									]))
-							])),
-						A2(
-						$elm$html$Html$tr,
-						_List_Nil,
-						_List_fromArray(
-							[
-								A2(
-								$elm$html$Html$td,
-								_List_Nil,
-								_List_fromArray(
-									[
-										A2(
-										$elm$html$Html$input,
-										_List_fromArray(
-											[
 												$elm$html$Html$Attributes$id('unicode'),
 												$elm$html$Html$Attributes$name('script'),
 												$elm$html$Html$Attributes$type_('radio'),
@@ -7897,6 +7860,43 @@ var $author$project$Main$scriptFieldSet = function (model) {
 												$elm$html$Html$Attributes$for('unicode')
 											]),
 										$author$project$Main$radioScriptLabelHtml(1))
+									]))
+							])),
+						A2(
+						$elm$html$Html$tr,
+						_List_Nil,
+						_List_fromArray(
+							[
+								A2(
+								$elm$html$Html$td,
+								_List_Nil,
+								_List_fromArray(
+									[
+										A2(
+										$elm$html$Html$input,
+										_List_fromArray(
+											[
+												$elm$html$Html$Attributes$id('latin'),
+												$elm$html$Html$Attributes$name('script'),
+												$elm$html$Html$Attributes$type_('radio'),
+												$elm$html$Html$Attributes$value('Latin'),
+												$elm$html$Html$Events$onInput($author$project$Types$SetScript),
+												$elm$html$Html$Attributes$checked(!model.bi.bf)
+											]),
+										_List_Nil)
+									])),
+								A2(
+								$elm$html$Html$td,
+								_List_Nil,
+								_List_fromArray(
+									[
+										A2(
+										$elm$html$Html$label,
+										_List_fromArray(
+											[
+												$elm$html$Html$Attributes$for('latin')
+											]),
+										$author$project$Main$radioScriptLabelHtml(0))
 									]))
 							]))
 					]))

--- a/031-flash/src/Main.elm
+++ b/031-flash/src/Main.elm
@@ -376,20 +376,6 @@ scriptFieldSet model =
             [ tr []
                 [ td []
                     [ input
-                        [ id "latin"
-                        , name "script"
-                        , type_ "radio"
-                        , value "Latin"
-                        , HE.onInput SetScript
-                        , checked <| model.settings.script == Latin
-                        ]
-                        []
-                    ]
-                , td [] [ label [ for "latin" ] <| radioScriptLabelHtml Latin ]
-                ]
-            , tr []
-                [ td []
-                    [ input
                         [ id "unicode"
                         , name "script"
                         , type_ "radio"
@@ -400,6 +386,20 @@ scriptFieldSet model =
                         []
                     ]
                 , td [] [ label [ for "unicode" ] <| radioScriptLabelHtml Unicode ]
+                ]
+            , tr []
+                [ td []
+                    [ input
+                        [ id "latin"
+                        , name "script"
+                        , type_ "radio"
+                        , value "Latin"
+                        , HE.onInput SetScript
+                        , checked <| model.settings.script == Latin
+                        ]
+                        []
+                    ]
+                , td [] [ label [ for "latin" ] <| radioScriptLabelHtml Latin ]
                 ]
             ]
         ]


### PR DESCRIPTION
 In the Settings page, put Devanagari as the top choice over ISO 15919.

Note that `elm.js` is compiled from the Elm code, so the changed file to pay attention to is `Main.elm`